### PR TITLE
changed logic for checking the scroll position of the container

### DIFF
--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -105,30 +105,34 @@ export class CarouselComponent {
   }
 
   private reachedEnd() {
-    const fatherContainer = this.carouselHtmlElement.querySelector('.content') as HTMLElement;
+    const fatherContainer = this.carouselHtmlElement.querySelector(
+      '.content'
+    ) as HTMLElement;
     const containerLeftPosition = fatherContainer.scrollLeft;
     const card = this.carouselHtmlElement.querySelector('.card-container');
     const cardWidth = card?.getBoundingClientRect().width!;
-    const cardsGap = parseInt(getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-gap'));
+    const cardsGap = parseInt(
+      getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-gap')
+    );
     const pxPerMovement = cardWidth + cardsGap;
     const movedTimes = containerLeftPosition / pxPerMovement;
     const showedCards = Number(
-      getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-number')
+      getComputedStyle(this.carouselHtmlElement).getPropertyValue(
+        '--cards-number'
+      )
     );
-    console.log(movedTimes);
-    console.log(this.cards().length - showedCards);
-
-    // We have reached the end of the cards, now go back to beginning
-    return movedTimes >= this.cards().length - showedCards
+    // We have reached the end of the cards, now go back to beginning (This will be triggered in the autoScroll method)
+    return movedTimes >= this.cards().length - showedCards;
   }
-
 
   // This method is currently not being used at all
   private startAutoScroll(direction: 'right' | 'left' = 'right') {
     let msPerMove = 2000;
     let intervalCounter = 0;
     const showedCards = Number(
-      getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-number')
+      getComputedStyle(this.carouselHtmlElement).getPropertyValue(
+        '--cards-number'
+      )
     );
     if (direction == 'right') {
       const currentInterval = setInterval(() => {
@@ -150,19 +154,11 @@ export class CarouselComponent {
     let msPerAutoMove = 2000;
     const firstMoveDelayMultiplier = 1.5; // Delay for the first move when restarting the scroll (back to left)
     if (!this.autoScrollLocked()) {
-      const showedCards = Number(
-        getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-number')
-      );
-      if (this.autoScrollLocked()) {
-        // Re-run logic with previous status. There won't be any movement until the scroll is unlocked
-        this.startStoppableAutoScroll();
-      } else {
-        this.scrollContainer('right');
-        if (this.reachedEnd()) {
-          // We have reached the end of the cards, now go back to beginning
-          this.scrollToEnd('left');
-          msPerAutoMove *= firstMoveDelayMultiplier; // Add delay on first move after going back to the first card
-        }
+      this.scrollContainer('right');
+      if (this.reachedEnd()) {
+        // Go back to beginning
+        this.scrollToEnd('left');
+        msPerAutoMove *= firstMoveDelayMultiplier; // Add delay on first move after going back to the first card
       }
     }
     const nextMovementTimeout = setTimeout(() => {
@@ -181,22 +177,26 @@ export class CarouselComponent {
 
   protected scrollContainer(direction: 'left' | 'right') {
     this.scrollLocked.set(true);
-    const fatherContainer = this.carouselHtmlElement.querySelector('.content') as HTMLElement;
+    const fatherContainer = this.carouselHtmlElement.querySelector(
+      '.content'
+    ) as HTMLElement;
     const containerLeftPosition = fatherContainer.scrollLeft;
     const card = this.carouselHtmlElement.querySelector('.card-container');
     const cardWidth = card?.getBoundingClientRect().width!;
-    const cardsGap = parseInt(getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-gap'));
+    const cardsGap = parseInt(
+      getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-gap')
+    );
     const pxPerMovement = cardWidth + cardsGap;
     let realMovement = pxPerMovement;
 
     if (direction == 'right') {
       if (containerLeftPosition % pxPerMovement != 0) {
-        realMovement -= (containerLeftPosition % pxPerMovement)
+        realMovement -= containerLeftPosition % pxPerMovement;
       }
       fatherContainer.scrollLeft += realMovement;
     } else {
       if (containerLeftPosition % pxPerMovement != 0) {
-        realMovement = (containerLeftPosition % pxPerMovement);
+        realMovement = containerLeftPosition % pxPerMovement;
       }
       fatherContainer.scrollLeft -= realMovement;
     }
@@ -206,12 +206,16 @@ export class CarouselComponent {
   }
 
   protected scrollToEnd(direction: 'left' | 'right') {
-    const content = this.carouselHtmlElement.querySelector('.content') as HTMLElement;
+    const content = this.carouselHtmlElement.querySelector(
+      '.content'
+    ) as HTMLElement;
     const card = this.carouselHtmlElement.querySelector('.card-container');
     const cardDimension = card?.getBoundingClientRect();
     const containerWidth = cardDimension?.width;
     const showedCards = Number(
-      getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-number')
+      getComputedStyle(this.carouselHtmlElement).getPropertyValue(
+        '--cards-number'
+      )
     );
     if (direction == 'right') {
       content.scrollLeft +=

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -104,7 +104,7 @@ export class CarouselComponent {
     }
   }
 
-  reachedEnd() {
+  private reachedEnd() {
     const fatherContainer = this.carouselHtmlElement.querySelector('.content') as HTMLElement;
     const containerLeftPosition = fatherContainer.scrollLeft;
     const card = this.carouselHtmlElement.querySelector('.card-container');
@@ -115,9 +115,14 @@ export class CarouselComponent {
     const showedCards = Number(
       getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-number')
     );
+    console.log(movedTimes);
+    console.log(this.cards().length - showedCards);
+
     // We have reached the end of the cards, now go back to beginning
-    return movedTimes == this.cards().length - showedCards
+    return movedTimes >= this.cards().length - showedCards
   }
+
+
   // This method is currently not being used at all
   private startAutoScroll(direction: 'right' | 'left' = 'right') {
     let msPerMove = 2000;
@@ -159,7 +164,6 @@ export class CarouselComponent {
           msPerAutoMove *= firstMoveDelayMultiplier; // Add delay on first move after going back to the first card
         }
       }
-      console.log(this.reachedEnd());
     }
     const nextMovementTimeout = setTimeout(() => {
       this.startStoppableAutoScroll();


### PR DESCRIPTION
Now the logic of checking the position is managed on an external method.
This new method checks the scroll position by dividing the left position of the scroll with the pxPerMovement and if you have reached the end the method returns true. If not, returns false.