### PR TITLE
Dynamic media queries

### DIFF
--- a/projects/carousel-app/src/app/components/carousel-implementation/card/card.component.css
+++ b/projects/carousel-app/src/app/components/carousel-implementation/card/card.component.css
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    width: 600px;
+    width: 400px;
 
     @media (max-width: 1200px) {
         width: 250px;

--- a/projects/carousel-app/src/app/components/carousel-implementation/card/card.component.css
+++ b/projects/carousel-app/src/app/components/carousel-implementation/card/card.component.css
@@ -2,6 +2,11 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    width: 600px;
+
+    @media (max-width: 1200px) {
+        width: 250px;
+    }
 
     & .card-img {
         height: 300px;

--- a/projects/carousel/src/lib/carousel.component.css
+++ b/projects/carousel/src/lib/carousel.component.css
@@ -3,23 +3,6 @@
   --cards-gap: 20px;
   --cards-number: 5;
   --arrow-distance: calc((100% - ((var(--cards-number) * var(--card-width)) + ((var(--cards-number) - 1) * var(--cards-gap))) ) / 2 - 65px);
-  
-  /* FIXME: Try to get cards number dynamically */
-  @media (max-width: 1500px) {
-    --cards-number: 4;
-  }
-
-  @media (max-width: 1200px) {
-    --cards-number: 3;
-  }
-
-  @media (max-width: 950px) {
-    --cards-number: 2;
-  }
-
-  @media (max-width: 650px) {
-    --cards-number: 1;
-  }
 }
 
 .container {
@@ -90,7 +73,7 @@
     /* End styles for removing scrollbar*/
 
     & .carousel-card-container {
-      flex: 0 0 var(--card-width);
+      flex: 0 0 auto;
       border: 1px solid #ccc;
       border-radius: 16px;
       overflow: hidden;
@@ -103,9 +86,5 @@
       }
 
     }
-  }
-
-  & .content::-webkit-scrollbar {
-    display: none;
   }
 }

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -45,22 +45,21 @@ export class CarouselComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.adjustCssVariables();
+      this.adjustCssVariables();
     window.addEventListener('resize', () => this.adjustCssVariables())
   }
 
   private adjustCssVariables() {
     const cardContainer = this.carouselHtmlElement.querySelector('.carousel-card-container') as HTMLElement;
     const cardContainerDimensions = cardContainer.getBoundingClientRect();
-    const cardWidth = cardContainerDimensions.width;
+    const cardWidth = cardContainerDimensions.width - 2;
     let mediaWidthMargin = (cardWidth * 1.5);
+    this.carouselHtmlElement.style.setProperty('--card-width', `${cardWidth}px`);
 
     if (cardWidth < 300) {
       mediaWidthMargin = (cardWidth * 2);
     }
-
-    this.carouselHtmlElement.style.setProperty('--card-width', `${cardWidth}px`);
-
+    
     if (window.innerWidth <= cardWidth + mediaWidthMargin) {
       this.carouselHtmlElement.style.setProperty('--cards-number', `1`);
     } else if (window.innerWidth <= (cardWidth * 2) + mediaWidthMargin) {
@@ -69,9 +68,12 @@ export class CarouselComponent implements OnInit, AfterViewInit {
       this.carouselHtmlElement.style.setProperty('--cards-number', `3`);
     } else if (window.innerWidth <= (cardWidth * 4) + mediaWidthMargin) {
       this.carouselHtmlElement.style.setProperty('--cards-number', `4`);
-    } else {
+    } else if (window.innerWidth <= (cardWidth * 5) + mediaWidthMargin){
       this.carouselHtmlElement.style.setProperty('--cards-number', `5`);
+    } else {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `6`);
     }
+
   }
 
   private reachedEnd() {
@@ -142,14 +144,13 @@ export class CarouselComponent implements OnInit, AfterViewInit {
     );
     const pxPerMovement = cardWidth + cardsGap;
     let realMovement = pxPerMovement;
-
     if (direction == 'right') {
-      if (containerLeftPosition % pxPerMovement != 0) {
+      if (containerLeftPosition % pxPerMovement > 10) {
         realMovement -= containerLeftPosition % pxPerMovement;
       }
       fatherContainer.scrollLeft += realMovement;
     } else {
-      if (containerLeftPosition % pxPerMovement != 0) {
+      if (containerLeftPosition % pxPerMovement > 10) {
         realMovement = containerLeftPosition % pxPerMovement;
       }
       fatherContainer.scrollLeft -= realMovement;

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -1,10 +1,12 @@
 import { CommonModule, NgClass } from '@angular/common';
 import {
+  AfterViewInit,
   Component,
   ContentChild,
   ElementRef,
   inject,
   input,
+  OnInit,
   signal,
   TemplateRef,
   ViewChild,
@@ -18,8 +20,9 @@ import { CardComponent } from './subcomponents/card/card.component';
   templateUrl: './carousel.component.html',
   styleUrl: './carousel.component.css',
 })
-export class CarouselComponent {
-  public scrollBehaviour = input<'auto' | 'manual-only'>('auto');
+export class CarouselComponent implements OnInit, AfterViewInit {
+ 
+  public scrollBehaviour = input<'auto' | 'manual-only'>('manual-only');
   private autoScrollConfig = inject(AUTO_SCROLL_CONFIG, { optional: true }); //User config for the scroll behavior
 
   protected autoScrollLocked = signal<boolean>(false); //For stopping auto scroll when hovering cards and arrows
@@ -38,6 +41,36 @@ export class CarouselComponent {
   ngOnInit(): void {
     if (this.scrollBehaviour() == 'auto') {
       this.startStoppableAutoScroll();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.adjustCssVariables();
+    window.addEventListener('resize', () => this.adjustCssVariables())
+  }
+
+  private adjustCssVariables() {
+    const cardContainer = this.carouselHtmlElement.querySelector('.carousel-card-container') as HTMLElement;
+    const cardContainerDimensions = cardContainer.getBoundingClientRect();
+    const cardWidth = cardContainerDimensions.width;
+    let mediaWidthMargin = (cardWidth * 1.5);
+
+    if (cardWidth < 300) {
+      mediaWidthMargin = (cardWidth * 2);
+    }
+
+    this.carouselHtmlElement.style.setProperty('--card-width', `${cardWidth}px`);
+
+    if (window.innerWidth <= cardWidth + mediaWidthMargin) {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `1`);
+    } else if (window.innerWidth <= (cardWidth * 2) + mediaWidthMargin) {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `2`);
+    } else if (window.innerWidth <= (cardWidth * 3) + mediaWidthMargin) {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `3`);
+    } else if (window.innerWidth <= (cardWidth * 4) + mediaWidthMargin) {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `4`);
+    } else {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `5`);
     }
   }
 


### PR DESCRIPTION
This includes:
- Media queries using JavaScript since I could not find any way to render the cards number in plain css, since it depends on the card width, which may vary from card to card

This allows to render the proper number of cards in the carousel view according to the width of the customized card. Thus, it works for any kind of card now.

Also solved a bug in the scroll behavior where sometimes it did not move the container the required px (It was missing one px and thus, the if condition was not triggered). The solution for this was to add 10px of margin before triggering the if condition. For more details, check the scrollContainer() method
