### PR TITLE
Enable customized number input for the maximum number of cards shown

### DIFF
--- a/projects/carousel-app/src/app/components/carousel-implementation/carousel-implementation.component.html
+++ b/projects/carousel-app/src/app/components/carousel-implementation/carousel-implementation.component.html
@@ -1,4 +1,4 @@
-<carousel [cards]="cards()" [maxShowedCards]="2">
+<carousel [cards]="cards()" [maxShowedCards]="5">
     <ng-template let-cardInfo>
         <custom-card [card]="cardInfo"></custom-card>
     </ng-template>

--- a/projects/carousel/src/lib/carousel.component.html
+++ b/projects/carousel/src/lib/carousel.component.html
@@ -39,7 +39,7 @@
                 <ng-container *ngTemplateOutlet="templateToUse; context: { $implicit: card }"></ng-container>
             </div>
         }
-    </div>
+    </div>  
 </div>
 
 

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -64,11 +64,17 @@ export class CarouselComponent implements OnInit, AfterViewInit {
       }
     }
     
+    let checked = false;
+
     for (let i = 1; i <= this.maxShowedCards(); i++) {
       if (window.innerWidth <= (cardWidth * i) + mediaWidthMargin) {
-          this.carouselHtmlElement.style.setProperty('--cards-number', `${i}`);
-          break; // We already know which is the cards number for this screen width. No need to check the rest
+        this.carouselHtmlElement.style.setProperty('--cards-number', `${i}`);
+        checked = true;
+        break; // We already know which is the cards number for this screen width. No need to check the rest
       }
+    }
+    if (!checked) {
+      this.carouselHtmlElement.style.setProperty('--cards-number', `${this.maxShowedCards()}`);
     }
 
   }


### PR DESCRIPTION
The previous PR was only working from smaller to bigger widths. Fixed remaining scenarios:

fix: now working from bigger to smaller widths too