### PR TITLE
Fix scroll behavior error margin checker

### DIFF
--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -142,24 +142,40 @@ export class CarouselComponent implements OnInit, AfterViewInit {
     const fatherContainer = this.carouselHtmlElement.querySelector(
       '.content'
     ) as HTMLElement;
-    const containerLeftPosition = fatherContainer.scrollLeft;
+    const containerLeftPosition = parseFloat(fatherContainer.scrollLeft.toFixed(2));
     const card = this.carouselHtmlElement.querySelector(
       '.carousel-card-container'
     );
-    const cardWidth = card?.getBoundingClientRect().width!;
+    if (!card) {
+      return;
+    }
+    const cardWidth = parseFloat((card.getBoundingClientRect().width!).toFixed(2));
     const cardsGap = parseInt(
       getComputedStyle(this.carouselHtmlElement).getPropertyValue('--cards-gap')
     );
     const pxPerMovement = cardWidth + cardsGap;
+
+    // Math for fixing movement in case you are in the middle of a card
     let realMovement = pxPerMovement;
+    const fixedMovement = containerLeftPosition % pxPerMovement;
+    let diff = fixedMovement;
+    const errorMargin = 10;
+    if (fixedMovement > errorMargin) {
+      diff = Math.abs((containerLeftPosition % pxPerMovement) - pxPerMovement);
+    }
     if (direction == 'right') {
-      if (containerLeftPosition % pxPerMovement > 10) {
-        realMovement -= containerLeftPosition % pxPerMovement;
+      if (diff > errorMargin) {
+        /*
+         This validation has to be done because the expected movement (containerLeftPosition % pxPerMovement) 
+         of the container sometimes is slightly different than 0
+        */
+        realMovement -= fixedMovement;
       }
       fatherContainer.scrollLeft += realMovement;
     } else {
-      if (containerLeftPosition % pxPerMovement > 10) {
-        realMovement = containerLeftPosition % pxPerMovement;
+      // Moving to the left side
+      if (diff > errorMargin) {
+        realMovement = fixedMovement;
       }
       fatherContainer.scrollLeft -= realMovement;
     }


### PR DESCRIPTION
In the previous version, we supposed that the error margin would always be containerLeftPosition % pxPerMovement, being a number in between 0 to 10. 

The problem with this verification was that sometimes the result of this operation was actually closer to the value of pxPerMovement instead of 0 --> pxPerMovement was actually a little bit greater that the containerLeftPosition.

This path was not being checked, which was causing the scroll not to work at all if the cards weren't scrolled manually. This was only happening with some cards and specific devices, but it was not an expected behavior